### PR TITLE
Fix background color

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -50,7 +50,21 @@ To output a simple bolded string, try this script:
 
 == INSTALL
 
+To install from rubygems, simple run:
+
   gem install win32console
+
+To install from source, make sure you have the Ruby development kit from
+RubyInstaller on your Windows host, install the following gems:
+
+  * rake
+  * hoe
+  * rake-compiler
+
+Then run the following:
+
+  rake gem
+  gem install pkg\win32console-1.3.0.gem
 
 == DEVELOPERS:
 

--- a/lib/Win32/Console.rb
+++ b/lib/Win32/Console.rb
@@ -208,23 +208,21 @@ module Win32
     end
 
     def DefaultBold # Foreground Intensity
-      self.AttrBits[4] == ?1
+      self.Attr[3] == 1
     end
 
     def DefaultUnderline # Background Intensity
-      self.AttrBits[0] == ?1
+      self.Attr[7] == 1
     end
 
     def DefaultForeground
-      self.AttrBits[5..7].reverse.to_i(2)
+      a = self.Attr
+      (0..2).map{|i| a[i] }.inject(0){|num, bit| (num << 1) + bit }
     end
 
     def DefaultBackground
-      self.AttrBits[1..3].reverse.to_i(2)
-    end
-
-    def AttrBits
-      sprintf("%08b",self.Attr)
+      a = self.Attr
+      (4..6).map{|i| a[i] }.inject(0){|num, bit| (num << 1) + bit }
     end
 
     def Size(*t)

--- a/lib/Win32/Console.rb
+++ b/lib/Win32/Console.rb
@@ -207,6 +207,26 @@ module Win32
       end
     end
 
+    def DefaultBold # Foreground Intensity
+      self.AttrBits[4] == ?1
+    end
+
+    def DefaultUnderline # Background Intensity
+      self.AttrBits[0] == ?1
+    end
+
+    def DefaultForeground
+      self.AttrBits[5..7].reverse.to_i(2)
+    end
+
+    def DefaultBackground
+      self.AttrBits[1..3].reverse.to_i(2)
+    end
+
+    def AttrBits
+      sprintf("%08b",self.Attr)
+    end
+
     def Size(*t)
       if t.size == 0
         col, row = API.GetConsoleScreenBufferInfo(@handle )

--- a/lib/Win32/Console.rb
+++ b/lib/Win32/Console.rb
@@ -29,6 +29,7 @@ module Win32
         @handle = API.CreateConsoleScreenBuffer( param1, param2,
                                                  CONSOLE_TEXTMODE_BUFFER )
       end
+      @attr_default = self.Attr
     end
 
     def Display
@@ -269,7 +270,7 @@ module Win32
     end
 
     def Cls()
-      attr = ATTR_NORMAL
+      attr = @attr_default
       x, y = Size()
       left, top, right , bottom = Window()
       vx = right  - left

--- a/lib/Win32/Console.rb
+++ b/lib/Win32/Console.rb
@@ -29,7 +29,11 @@ module Win32
         @handle = API.CreateConsoleScreenBuffer( param1, param2,
                                                  CONSOLE_TEXTMODE_BUFFER )
       end
-      @attr_default = self.Attr
+
+      # Preserve original attribute setting, so Cls can use it
+      if t == STD_OUTPUT_HANDLE or t == STD_ERROR_HANDLE
+        @attr_default = self.Attr
+      end
     end
 
     def Display
@@ -270,7 +274,7 @@ module Win32
     end
 
     def Cls()
-      attr = @attr_default
+      attr = @attr_default || ATTR_NORMAL
       x, y = Size()
       left, top, right , bottom = Window()
       vx = right  - left

--- a/lib/Win32/Console/ANSI.rb
+++ b/lib/Win32/Console/ANSI.rb
@@ -87,10 +87,14 @@ module Win32
           super(fd, 'w')
           @Out = Win32::Console.new(handle)
           @x = @y = 0           # to save cursor position
-          @foreground = 7
-          @background = 0
-          @bold =
-          @underline =
+          @default_foreground = @Out.DefaultForeground
+          @default_background = @Out.DefaultBackground
+          @default_bold       = @Out.DefaultBold
+          @default_underline  = @Out.DefaultUnderline
+          @foreground = @default_foreground
+          @background = @default_background
+          @bold       = @default_bold
+          @underline  = @default_underline
           @revideo =
           @concealed = nil
           @conv = 1        # char conversion by default
@@ -159,10 +163,10 @@ module Win32
                     atv = attr.to_i
                     case atv
                     when 0  # ESC[0m reset
-                      @foreground = 7
-                      @background = 0
-                      @bold =
-                      @underline =
+                      @foreground = @default_foreground
+                      @background = @default_background
+                      @bold       = @default_bold
+                      @underline  = @default_underline
                       @revideo =
                       @concealed = nil
                     when 1


### PR DESCRIPTION
Hi there,

I realise this gem is deprecated, but we've been investigating its usage at Puppetlabs for our own console purposes and we feel that its less intrusive then ansicon. The only problem I have is the preservation of background color really. I've taken the patches from Gordon Thiesfeld and included them in this pull request.

Is there any chance of merging this in and releasing a new gem with this tiny fix? I'd rather avoid a fork or to maintain our own copy just for our own purposes.

Thanks :-).

ken.
